### PR TITLE
Reusable upgrade module & Upgrade postgresql

### DIFF
--- a/modules/database/postgres/default.nix
+++ b/modules/database/postgres/default.nix
@@ -3,5 +3,6 @@
     ./options.nix
     ./postgresql.nix
     ./pgbouncer.nix
+    ./upgrade.nix
   ];
 }

--- a/modules/database/postgres/postgresql.nix
+++ b/modules/database/postgres/postgresql.nix
@@ -14,7 +14,7 @@ in
   config = lib.mkIf cfg.enable {
     services.postgresql = {
       enable = true;
-      package = pkgs.postgresql_16;
+      package = pkgs.postgresql_17;
       dataDir = cfg.dataDir;
       enableTCPIP = true;
 

--- a/modules/database/postgres/upgrade.nix
+++ b/modules/database/postgres/upgrade.nix
@@ -1,0 +1,69 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.mares.database.postgres.upgrade;
+  pgCfg = config.services.postgresql;
+in
+{
+  options.mares.database.postgres.upgrade = {
+    enable = lib.mkEnableOption "PostgreSQL upgrade script";
+
+    targetPackage = lib.mkOption {
+      type = lib.types.package;
+      description = "PostgreSQL package to upgrade to";
+      example = lib.literalExpression "pkgs.postgresql_17";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [
+      (pkgs.writeScriptBin "upgrade-pg-cluster" ''
+        set -eux
+
+        # Derive paths from current config and target package
+        OLDDATA="${pgCfg.dataDir}"
+        OLDBIN="${pgCfg.finalPackage}/bin"
+
+        NEWDATA="$(dirname "$OLDDATA")/${cfg.targetPackage.psqlSchema}"
+        NEWBIN="${cfg.targetPackage}/bin"
+
+        echo "=== PostgreSQL Upgrade ==="
+        echo "Old: $OLDDATA ($("$OLDBIN/postgres" --version))"
+        echo "New: $NEWDATA ($("$NEWBIN/postgres" --version))"
+        echo ""
+
+        read -p "Stop postgresql and begin upgrade? [y/N] " -n 1 -r
+        echo
+        if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+          echo "Aborted."
+          exit 1
+        fi
+
+        systemctl stop postgresql
+
+        install -d -m 0700 -o postgres -g postgres "$NEWDATA"
+        cd "$NEWDATA"
+
+        sudo -u postgres "$NEWBIN/initdb" -D "$NEWDATA" ${lib.escapeShellArgs pgCfg.initdbArgs}
+
+        sudo -u postgres "$NEWBIN/pg_upgrade" \
+          --old-datadir "$OLDDATA" --new-datadir "$NEWDATA" \
+          --old-bindir "$OLDBIN" --new-bindir "$NEWBIN" \
+          "$@"
+
+        echo ""
+        echo "=== Upgrade Complete ==="
+        echo "Next steps:"
+        echo "1. Update postgresql.nix: package = pkgs.postgresql_${cfg.targetPackage.psqlSchema};"
+        echo "2. Set upgrade.enable = false"
+        echo "3. Deploy the updated configuration"
+        echo "4. Run: sudo -u postgres vacuumdb --all --analyze-in-stages"
+      '')
+    ];
+  };
+}

--- a/roles/postgres.nix
+++ b/roles/postgres.nix
@@ -12,6 +12,11 @@ in
     ../modules/database/postgres
   ];
 
+  mares.database.postgres.upgrade = {
+    enable = false;
+    targetPackage = pkgs.postgresql_17;
+  };
+
   sops-vault.items = [ "pgsql" ];
 
   fileSystems."/mnt/postgres-data" = {


### PR DESCRIPTION
Upgraded PostgreSQL from 16 to 17.

Added reusable upgrade module (modules/database/postgres/upgrade.nix) for future major version migrations. Usage:

1. Set mares.database.postgres.upgrade = { enable = true; targetPackage = pkgs.postgresql_XX; }
2. Deploy, then run upgrade-pg-cluster --link --jobs 4 on server
3. Update postgresql.nix package version, disable upgrade, deploy again
4. Run sudo -u postgres vacuumdb --all --analyze-in-stages