### PR TITLE
Add evcc for EV charging management

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -81,11 +81,11 @@
         "sops-nix": "sops-nix"
       },
       "locked": {
-        "lastModified": 1767741576,
-        "narHash": "sha256-Y1elQkKSlcpccdLpwUAYlM4IB8E4rAcg3DKG97EPYyM=",
+        "lastModified": 1767999574,
+        "narHash": "sha256-QUgBXEX/MbxLNPEaIpzpjh83GyhR7yhneca9CNl51lI=",
         "ref": "refs/heads/main",
-        "rev": "7f1c563a9e72379988d270e1dcf97e0fe01e022e",
-        "revCount": 42,
+        "rev": "bfe9a1b9201e4a9b381cb797f6d7b8519cfba336",
+        "revCount": 43,
         "type": "git",
         "url": "ssh://git@github.com/omares/nix-sops-vault.git"
       },

--- a/modules/automation/evcc/default.nix
+++ b/modules/automation/evcc/default.nix
@@ -1,0 +1,6 @@
+{
+  imports = [
+    ./options.nix
+    ./service.nix
+  ];
+}

--- a/modules/automation/evcc/options.nix
+++ b/modules/automation/evcc/options.nix
@@ -1,0 +1,20 @@
+{ lib, ... }:
+{
+  options.mares.automation.evcc = {
+    enable = lib.mkEnableOption "evcc";
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Whether to open the firewall for evcc UI and OCPP.";
+    };
+    secretsFile = lib.mkOption {
+      type = lib.types.path;
+      description = "Path to the environment file containing secrets for envsubst.";
+    };
+    settings = lib.mkOption {
+      type = lib.types.attrs;
+      default = { };
+      description = "Structured evcc settings (YAML).";
+    };
+  };
+}

--- a/modules/automation/evcc/service.nix
+++ b/modules/automation/evcc/service.nix
@@ -1,0 +1,22 @@
+{
+  config,
+  lib,
+  ...
+}:
+let
+  cfg = config.mares.automation.evcc;
+in
+{
+  config = lib.mkIf cfg.enable {
+    networking.firewall.allowedTCPPorts = lib.mkIf cfg.openFirewall [
+      7070
+      8887
+    ];
+
+    services.evcc = {
+      enable = true;
+      environmentFile = cfg.secretsFile;
+      settings = cfg.settings;
+    };
+  };
+}

--- a/modules/automation/home-assistant/default.nix
+++ b/modules/automation/home-assistant/default.nix
@@ -4,5 +4,6 @@
     ./service.nix
     ./automations.nix
     ./shelly.nix
+    ./helpers.nix
   ];
 }

--- a/modules/automation/home-assistant/ha-evcc.nix
+++ b/modules/automation/home-assistant/ha-evcc.nix
@@ -1,0 +1,24 @@
+{
+  lib,
+  buildHomeAssistantComponent,
+  fetchFromGitHub,
+}:
+
+buildHomeAssistantComponent rec {
+  owner = "marq24";
+  domain = "evcc_intg";
+  version = "2026.1.1";
+
+  src = fetchFromGitHub {
+    owner = "marq24";
+    repo = "ha-evcc";
+    rev = version;
+    hash = "sha256-8f0xJgC90yr6HHrm5OBF6LHlP5AUkVz5Ep9Wcfu9rtQ=";
+  };
+
+  meta = with lib; {
+    description = "Home Assistant integration for evcc - Solar Charging";
+    homepage = "https://github.com/marq24/ha-evcc";
+    license = licenses.asl20;
+  };
+}

--- a/modules/automation/home-assistant/helpers.nix
+++ b/modules/automation/home-assistant/helpers.nix
@@ -1,0 +1,59 @@
+# Home Assistant helper sensors - templates and integrations
+{
+  config,
+  lib,
+  ...
+}:
+let
+  cfg = config.mares.home-assistant;
+in
+{
+  config = lib.mkIf cfg.enable {
+    services.home-assistant.config = lib.mkMerge [
+      # Battery energy helpers (requires evcc)
+      (lib.mkIf cfg.evcc.enable {
+        template = [
+          {
+            sensor = [
+              {
+                name = "Battery Charge Power";
+                unit_of_measurement = "W";
+                device_class = "power";
+                state_class = "measurement";
+                # evcc convention: negative = charging
+                state = "{{ max(0, states('sensor.evcc_battery_power') | float(0) * -1) }}";
+              }
+              {
+                name = "Battery Discharge Power";
+                unit_of_measurement = "W";
+                device_class = "power";
+                state_class = "measurement";
+                # evcc convention: positive = discharging
+                state = "{{ max(0, states('sensor.evcc_battery_power') | float(0)) }}";
+              }
+            ];
+          }
+        ];
+
+        sensor = [
+          {
+            platform = "integration";
+            source = "sensor.battery_charge_power";
+            name = "Battery Energy In";
+            unit_prefix = "k";
+            round = 2;
+            method = "left";
+          }
+          {
+            platform = "integration";
+            source = "sensor.battery_discharge_power";
+            name = "Battery Energy Out";
+            unit_prefix = "k";
+            round = 2;
+            method = "left";
+          }
+        ];
+      })
+    ];
+  };
+}

--- a/modules/automation/home-assistant/options.nix
+++ b/modules/automation/home-assistant/options.nix
@@ -127,5 +127,13 @@ in
     scenePresets = {
       enable = mkEnableOption "Scene Presets - Hue-like color picker for lights";
     };
+
+    evcc = {
+      enable = mkEnableOption "evcc integration for EV charging control";
+    };
+
+    fronius = {
+      enable = mkEnableOption "Fronius Solar integration for inverter and smart meter";
+    };
   };
 }

--- a/modules/automation/home-assistant/service.nix
+++ b/modules/automation/home-assistant/service.nix
@@ -12,10 +12,12 @@
 let
   cfg = config.mares.home-assistant;
   merossLan = pkgs.callPackage ./meross-lan.nix { };
+  haEvcc = pkgs.callPackage ./ha-evcc.nix { };
   merossComponents = lib.optionals cfg.meross.enable [ merossLan ];
   scenePresetsComponents = lib.optionals cfg.scenePresets.enable [
     pkgs.home-assistant-custom-components.scene_presets
   ];
+  evccComponents = lib.optionals cfg.evcc.enable [ haEvcc ];
 in
 {
   config = lib.mkIf cfg.enable {
@@ -28,7 +30,7 @@ in
     services.home-assistant = {
       enable = true;
       configDir = cfg.configDir;
-      customComponents = merossComponents ++ scenePresetsComponents;
+      customComponents = merossComponents ++ scenePresetsComponents ++ evccComponents;
 
       extraPackages = ps: [
         ps.psycopg2
@@ -51,7 +53,8 @@ in
       ++ cfg.extraComponents
       ++ lib.optionals cfg.shelly.enable [ "shelly" ]
       ++ lib.optionals cfg.influxdb.enable [ "influxdb" ]
-      ++ lib.optionals cfg.homekit.enable [ "homekit" ];
+      ++ lib.optionals cfg.homekit.enable [ "homekit" ]
+      ++ lib.optionals cfg.fronius.enable [ "fronius" ];
 
       # Note: MQTT broker connection must be configured via UI after onboarding
       # (Settings > Devices & Services > Add Integration > MQTT)

--- a/modules/infrastructure/nodes.nix
+++ b/modules/infrastructure/nodes.nix
@@ -449,6 +449,27 @@ in
         };
       };
 
+      evcc-01 = {
+        tags = [ "automation" ];
+        roles = [
+          config.flake.nixosModules.role-evcc
+          config.flake.nixosModules.role-monitoring-client
+          config.flake.nixosModules.role-atuin-client
+        ];
+
+        host = "10.10.22.197";
+
+        dns = {
+          vlan = "vm";
+        };
+
+        proxy = {
+          port = 7070;
+          subdomains = [ "evcc" ];
+          websockets = true;
+        };
+      };
+
       unifi = {
         managed = false;
 

--- a/roles/evcc.nix
+++ b/roles/evcc.nix
@@ -1,0 +1,126 @@
+{
+  config,
+  mares,
+  ...
+}:
+let
+  mqttNode = mares.infrastructure.nodes.mqtt-01;
+in
+{
+  imports = [ ../modules/automation/evcc ];
+
+  sops-vault.items = [ "evcc" ];
+
+  # Generate the environment file for envsubst
+  # Vault item: evcc
+  # Expected keys: mqtt_password, bmw_client_d, bmw_vin, ostrom_client_id, ostrom_client_secret, sponsor_token
+  sops.templates."evcc-env".content = ''
+    MQTT_PASSWORD=${config.sops.placeholder.evcc-mqtt_password}
+    BMW_CLIENTID=${config.sops.placeholder.evcc-bmw_clientid}
+    BMW_VIN=${config.sops.placeholder.evcc-bmw_vin}
+    OSTROM_ID=${config.sops.placeholder.evcc-ostrom_client_id}
+    OSTROM_SECRET=${config.sops.placeholder.evcc-ostrom_client_secret}
+    SPONSOR_TOKEN=${config.sops.placeholder.evcc-sponsor_token}
+  '';
+
+  mares.automation.evcc = {
+    enable = true;
+    secretsFile = config.sops.templates."evcc-env".path;
+
+    settings = {
+
+      interval = "30s";
+      sponsortoken = "${"\${SPONSOR_TOKEN}"}";
+
+      mqtt = {
+        broker = "tls://${mqttNode.dns.fqdn}:8883";
+        topic = "evcc";
+        user = "evcc";
+        password = "\${MQTT_PASSWORD}";
+      };
+
+      meters = [
+        {
+          name = "fronius_smart_meter";
+          type = "template";
+          template = "sunspec-meter";
+          usage = "grid";
+          modbus = "tcpip";
+          id = 240;
+          host = "192.168.20.24";
+          port = 502;
+        }
+        {
+          name = "fronius_symo_inverter";
+          type = "template";
+          template = "sunspec-inverter";
+          usage = "pv";
+          modbus = "tcpip";
+          id = 1;
+          host = "192.168.20.24";
+          port = 502;
+        }
+        {
+          name = "varta_pulse_neo";
+          type = "template";
+          template = "varta";
+          usage = "battery";
+          host = "192.168.20.129";
+        }
+      ];
+
+      chargers = [
+        {
+          name = "fronius_wattpilot";
+          type = "template";
+          template = "ocpp-goe";
+          stationid = "91008988";
+        }
+      ];
+
+      loadpoints = [
+        {
+          title = "Carport";
+          charger = "fronius_wattpilot";
+          vehicle = "bmw_ix40";
+          mode = "pv";
+        }
+      ];
+
+      vehicles = [
+        {
+          name = "bmw_ix40";
+          type = "template";
+          title = "BMW iX40";
+          template = "cardata";
+          clientid = "\${BMW_CLIENTID}";
+          vin = "\${BMW_VIN}";
+          capacity = 76.6;
+          streaming = true;
+        }
+      ];
+
+      tariffs = {
+        grid = {
+          type = "template";
+          template = "ostrom";
+          clientid = "\${OSTROM_ID}";
+          clientsecret = "\${OSTROM_SECRET}";
+        };
+        feedin = {
+          type = "fixed";
+          price = 0.0877;
+        };
+      };
+
+      site = {
+        title = "Mares Home";
+        meters = {
+          grid = "fronius_smart_meter";
+          pv = [ "fronius_symo_inverter" ];
+          battery = [ "varta_pulse_neo" ];
+        };
+      };
+    };
+  };
+}

--- a/roles/hass.nix
+++ b/roles/hass.nix
@@ -54,6 +54,8 @@ in
     homekit.enable = true;
     meross.enable = true;
     scenePresets.enable = true;
+    evcc.enable = true;
+    fronius.enable = true;
 
     influxdb = {
       enable = true;


### PR DESCRIPTION
Adds EVCC to manage EV charging. EVCC coordinates the Fronius inverter, Smart Pilot, Wattpilot charger, and Varta battery through local APIs (Modbus/TCP). Real-time price data for the dynamic electricity tariff is retrieved from Ostrom.

Home Assistant integration is achieved via the EVCC integration that retrieves information through the API, as the MQTT solution would require manual creation of all entities. The Fronius plugin provides accurate grid import/export readings, as EVCC only exports these as a single value, and the Riemann sum helpers smooth out data, which creates inaccuracies.